### PR TITLE
Adding in a travis CI build and build status on the readme md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+node_js:
+  - 9
 install:
   - npm install
 script:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # trello-vue
 
+[![Build Status](https://travis-ci.com/srini85/trello-vue.svg?branch=master)](https://travis-ci.com/srini85/trello-vue)
+
 > A Vue.js project
 
 ## Build Setup
 
-``` bash
+```bash
 # install dependencies
 npm install
 


### PR DESCRIPTION
@nicoleson - adding in a simple travis ci build to be able to run the build on a build machine so you can see if the build is passing or failing. just a starting point ..